### PR TITLE
Change mime type to application/msgpack

### DIFF
--- a/AFMsgPackSerialization/AFMsgPackRequestSerializer.m
+++ b/AFMsgPackSerialization/AFMsgPackRequestSerializer.m
@@ -59,7 +59,7 @@
         return mutableRequest;
     }
 
-    [mutableRequest setValue:@"application/x-msgpack" forHTTPHeaderField:@"Content-Type"];
+    [mutableRequest setValue:@"application/msgpack" forHTTPHeaderField:@"Content-Type"];
     [mutableRequest setHTTPBody:[MsgPackSerialization dataWithMsgPackObject:parameters options:self.writingOptions error:error]];
 
     return mutableRequest;

--- a/AFMsgPackSerialization/AFMsgPackResponseSerializer.h
+++ b/AFMsgPackSerialization/AFMsgPackResponseSerializer.h
@@ -28,7 +28,7 @@
 
  By default, `AFMsgPackSerializer` accepts the following MIME types:
 
- - `application/x-msgpack`
+ - `application/msgpack`
  */
 @interface AFMsgPackResponseSerializer : AFHTTPResponseSerializer
 

--- a/AFMsgPackSerialization/AFMsgPackResponseSerializer.m
+++ b/AFMsgPackSerialization/AFMsgPackResponseSerializer.m
@@ -41,7 +41,7 @@
         return nil;
     }
 
-    self.acceptableContentTypes = [NSSet setWithObjects:@"application/x-msgpack", nil];
+    self.acceptableContentTypes = [NSSet setWithObjects:@"application/msgpack", nil];
 
     return self;
 }


### PR DESCRIPTION
According to RFC 6838: "Note that types with names beginning with "x-" are no longer considered to be members of this tree (see [RFC6648]).", which suggests that the mime type should probably be `application/msgpack`. Obviously, this is a breaking change, so I understand if you don't want to accept it.
